### PR TITLE
[CZ-444] fix : 유저 <-> 카테고리 엔티티 무한 참조 버그 수정

### DIFF
--- a/src/main/java/com/example/manymanyUsers/user/domain/CategoryEntity.java
+++ b/src/main/java/com/example/manymanyUsers/user/domain/CategoryEntity.java
@@ -23,10 +23,6 @@ public class CategoryEntity {
     @Enumerated(EnumType.STRING)
     private Category category;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "USER_ID")
-    private User user;
-
     public Category toCategory() {
         return this.getCategory();
     }

--- a/src/main/java/com/example/manymanyUsers/user/domain/CategoryRespository.java
+++ b/src/main/java/com/example/manymanyUsers/user/domain/CategoryRespository.java
@@ -6,6 +6,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CategoryRespository extends JpaRepository<CategoryEntity, Long> {
 
-    void deleteByUser(User user);
-
 }

--- a/src/main/java/com/example/manymanyUsers/user/domain/User.java
+++ b/src/main/java/com/example/manymanyUsers/user/domain/User.java
@@ -121,5 +121,4 @@ public class User extends BaseTimeEntity {
         }
         return ageGroup;
     }
-
 }

--- a/src/main/java/com/example/manymanyUsers/user/service/UserService.java
+++ b/src/main/java/com/example/manymanyUsers/user/service/UserService.java
@@ -172,8 +172,15 @@ public class UserService {
 
 
         if (!isEqual) {
-            categoryRespository.deleteByUser(findUser);
-            addInterestCategory(categoryList, userId);
+            List<CategoryEntity> findUserCategoryLists = findUser.getCategoryLists();
+            for (Category list : categoryList) {
+                CategoryEntity category = new CategoryEntity();
+                category.setCategory(list);
+                categoryRespository.save(category);
+
+                findUserCategoryLists.add(category);
+                userRepository.save(findUser);
+            }
         }
 
 

--- a/src/main/java/com/example/manymanyUsers/vote/service/VoteService.java
+++ b/src/main/java/com/example/manymanyUsers/vote/service/VoteService.java
@@ -196,6 +196,7 @@ public class VoteService {
             voteList=voteRepository.findParticipatedVoteByUser(findUser,pageRequest);
         }
         //북마크한 vote
+
 //        else if(type.equals("bookmarked")){
 //            voteList=voteRepository.findAllByBookmarked(findUser);
 //        }


### PR DESCRIPTION
## 📑 작업리스트

- 유저와 유저안의 카테고리 엔티티가 서로 무한 참조하는 버그를 수정하였습니다.

## 📘 리뷰노트

- User 엔티티를 조회시 User 안의 Category 객체가 같이 조회되는데 Category 엔티티 안에도 User 가 존재하여 서로를 무한 참조하여
StackOverFlow 에러가 발생하는 버그를 해결하였습니다.